### PR TITLE
bugfix: for N > 1860 we get an integer overflow => use float range

### DIFF
--- a/genhurst.py
+++ b/genhurst.py
@@ -46,7 +46,7 @@ def genhurst(S,q):
             dV = S[np.arange(tt,L,tt)] - S[np.arange(tt,L,tt)-tt] 
             VV = S[np.arange(tt,L+tt,tt)-tt]
             N = len(dV) + 1
-            X = np.arange(1,N+1)
+            X = np.arange(1,N+1,dtype=np.float64)
             Y = VV
             mx = np.sum(X)/N
             SSxx = np.sum(X**2) - N*mx**2
@@ -55,7 +55,7 @@ def genhurst(S,q):
             cc1 = SSxy/SSxx
             cc2 = my - cc1*mx
             ddVd = dV - cc1
-            VVVd = VV - np.multiply(cc1,np.arange(1,N+1)) - cc2
+            VVVd = VV - np.multiply(cc1,np.arange(1,N+1,dtype=np.float64)) - cc2
             mcord[tt-1] = np.mean( np.abs(ddVd)**q )/np.mean( np.abs(VVVd)**q )
             
         mx = np.mean(np.log10(x))


### PR DESCRIPTION
T. Aste uses custom code for the line fitting. This version of least squares is susceptible to integer overflow errors. For N = 1861 we get

```python
>>> np.sum(np.arange(1, 1862) ** 2)
-2144821865
```

This problem did not occur in the original MATLAB code since MATLAB seems to switch to float automatically (tested using octave):

```octave
octave:8> sum((1:1861) .^ 2)
ans =    2.1501e+09
```

We can fix this problem by telling numpy to generate the range as float64 instead of int32:

```python
>>> np.sum(np.arange(1, 1862, dtype=np.float64) ** 2)
2150145431.0
```